### PR TITLE
Add ability to customize navigation item from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ class Handler extends ExceptionHandler
     }
 ```
 
+## Custom navigation menu
+
+By default, we set label to Exception under System group in navigation, you can easily customize it by:
+
+Publishing config files
+
+```bash
+php artisan vendor:publish --tag filament-exceptions-config
+```
+
+then update navigation property to your preferences
+```php
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Exceptions',
+        'group' => 'System',
+        'icon' => 'heroicon-o-chip',
+    ]
+];
+```
 
 
 ## Testing

--- a/config/filament-exceptions.php
+++ b/config/filament-exceptions.php
@@ -1,6 +1,9 @@
 <?php
 
-// config for BezhanSalleh/FilamentExceptions
 return [
-
+    'navigation' => [
+        'label' => 'Exceptions',
+        'group' => 'System',
+        'icon' => 'heroicon-o-chip',
+    ]
 ];

--- a/src/Resources/ExceptionResource.php
+++ b/src/Resources/ExceptionResource.php
@@ -18,12 +18,12 @@ class ExceptionResource extends Resource
 
     protected static function getNavigationLabel(): string
     {
-        return config('filament-exceptions.navigation.label', 'Exceptions');
+        return __(config('filament-exceptions.navigation.label', 'Exceptions'));
     }
 
     public static function getNavigationGroup(): ?string
     {
-        return config('filament-exceptions.navigation.group', 'System');
+        return __(config('filament-exceptions.navigation.group', 'System'));
     }
 
     protected static function getNavigationIcon(): string

--- a/src/Resources/ExceptionResource.php
+++ b/src/Resources/ExceptionResource.php
@@ -16,9 +16,20 @@ class ExceptionResource extends Resource
 {
     protected static ?string $model = Exception::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-chip';
+    protected static function getNavigationLabel(): string
+    {
+        return config('filament-exceptions.navigation.label', 'Exceptions');
+    }
 
-    protected static ?string $navigationLabel = 'Exceptions';
+    public static function getNavigationGroup(): ?string
+    {
+        return config('filament-exceptions.navigation.group', 'System');
+    }
+
+    protected static function getNavigationIcon(): string
+    {
+        return config('filament-exceptions.navigation.icon', 'heroicon-o-chip');
+    }
 
     public static function form(Form $form): Form
     {


### PR DESCRIPTION
This PR will add the ability to update navigation from the config file

```php
<?php
return [
    'navigation' => [
        'label' => 'Exceptions',
        'group' => 'System',
        'icon' => 'heroicon-o-chip',
    ]
];
```

By the default, it will have these values
