### PR TITLE
Update code-preview.blade.php

### DIFF
--- a/resources/views/components/code-preview.blade.php
+++ b/resources/views/components/code-preview.blade.php
@@ -14,7 +14,7 @@
                     </dt>
                     <dd
                         class="mt-1 text-sm leading-5 text-gray-900 break-words dark:text-gray-200 sm:mt-0 sm:col-span-2">
-                        {{ is_array($values) ? implode(' ', $values) : $values }}
+                        {{ is_array($values) ? implode(' ', collect($values)->flatten()->toArray()) : $values }}
                     </dd>
                 </div>
             @empty


### PR DESCRIPTION
When array exists in the elements of `$values`, the page errors out with `ErrorException(code: 0): Array to string conversion`.

This PR leverages on Laravel's Collection API to ensure that no array exists in `$values`, before applying the `implode()` operation.

Closes #16