### PR TITLE
Add Custom Model Support & Fix Iterator Errors

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
-            testbench: 7.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1]
-        laravel: [9.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
+          - laravel: 10.*
             testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -78,11 +78,42 @@ class Handler extends ExceptionHandler
 
 ## Configuration
 The configuration file filament-exceptions.php is automatically published into your config directory.
-You can change icons and navigations settings as well as the active pill and slug there.
 
-* **Mass Pruning**: By default exceptions older than a week are scheduled to be pruned daily. You can change the `period` by providing a date in the config or using carbon.
-> **Note**
-> in order for the schedule to work you need to make sure that you have configured your server if not follow this link on how to configure it. [Running The Scheduler](https://laravel.com/docs/9.x/scheduling#running-the-scheduler)
+The config file provides you with multiple options to customize the plugin.
+
+### Mass Pruning
+By default Filament Exceptions is configured to prune exceptions older than 1 week.
+
+To modify how long you'd like to store records for you can supply a Carbon object like so
+
+```php
+'period' => now()->subWeek(), // 1 week
+'period' => now()->subDay(), // 1 day
+'period' => now()->subDays(3), // 3 days
+```
+> **Note** This requires laravel scheduler to be setup and configured in order to work. You can see how to do that here  [Running The Scheduler](https://laravel.com/docs/10.x/scheduling#running-the-scheduler)
+ 
+### Custom Exception Model
+For those who need to change the model this is possible using the configuration file.
+
+```php
+    'exception_model' => Exception::class,
+```
+
+When creating your new exception model you should extend the default model
+
+```php
+<?php
+
+namespace App\Models;
+
+use BezhanSalleh\FilamentExceptions\Models\Exception as BaseException;
+
+class Exception extends BaseException
+{
+
+}
+```
 
 ## Theme
 By default the plugin uses the default theme of Filamentphp, but if you are using a custom theme then include the plugins view path into the content array of your tailwind.config.js file:

--- a/config/filament-exceptions.php
+++ b/config/filament-exceptions.php
@@ -1,5 +1,7 @@
 <?php
 
+use BezhanSalleh\FilamentExceptions\Models\Exception;
+
 return [
 
     'slug' => 'exceptions',
@@ -12,6 +14,8 @@ return [
 
     /** Whether to show a navigation badge. No effect, if navigation_enabled it set to false. */
     'navigation_badge' => true,
+
+    'exception_model' => Exception::class,
 
     /** Icons to use for navigation (if enabled) and pills */
     'icons' => [
@@ -26,27 +30,27 @@ return [
     'is_globally_searchable' => false,
 
     /**-------------------------------------------------
-    * Change the default active tab
-    *
-    * Exception => 1 (Default)
-    * Headers => 2
-    * Cookies => 3
-    * Body => 4
-    * Queries => 5
-    */
+     * Change the default active tab
+     *
+     * Exception => 1 (Default)
+     * Headers => 2
+     * Cookies => 3
+     * Body => 4
+     * Queries => 5
+     */
     'active_tab' => 5,
 
     /**-------------------------------------------------
-    * Here you can define when the exceptions should be pruned
-    * The default is 7 days (a week)
-    * The format for providing period should follow carbon's format. i.e.
-    * 1 day => 'subDay()',
-    * 3 days => 'subDays(3)',
-    * 7 days => 'subWeek()',
-    * 1 month => 'subMonth()',
-    * 2 months => 'subMonths(2)',
-    *
-    */
+     * Here you can define when the exceptions should be pruned
+     * The default is 7 days (a week)
+     * The format for providing period should follow carbon's format. i.e.
+     * 1 day => 'subDay()',
+     * 3 days => 'subDays(3)',
+     * 7 days => 'subWeek()',
+     * 1 month => 'subMonth()',
+     * 2 months => 'subMonths(2)',
+     *
+     */
 
     'period' => now()->subWeek(),
 ];

--- a/config/filament-exceptions.php
+++ b/config/filament-exceptions.php
@@ -4,6 +4,8 @@ use BezhanSalleh\FilamentExceptions\Models\Exception;
 
 return [
 
+    'exception_model' => Exception::class,
+
     'slug' => 'exceptions',
 
     /** Show or hide in navigation/sidebar */
@@ -14,8 +16,6 @@ return [
 
     /** Whether to show a navigation badge. No effect, if navigation_enabled it set to false. */
     'navigation_badge' => true,
-
-    'exception_model' => Exception::class,
 
     /** Icons to use for navigation (if enabled) and pills */
     'icons' => [
@@ -52,5 +52,5 @@ return [
      *
      */
 
-    'period' => now()->subWeek(),
+    'period' => now()->subDays(5),
 ];

--- a/config/filament-exceptions.php
+++ b/config/filament-exceptions.php
@@ -52,5 +52,5 @@ return [
      *
      */
 
-    'period' => now()->subDays(5),
+    'period' => now()->subWeek(),
 ];

--- a/src/FilamentExceptions.php
+++ b/src/FilamentExceptions.php
@@ -2,11 +2,11 @@
 
 namespace BezhanSalleh\FilamentExceptions;
 
-use BezhanSalleh\FilamentExceptions\Models\Exception;
+
+use BezhanSalleh\FilamentExceptions\Models\Exception as ExceptionModel;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Spatie\LaravelIgnition\Recorders\QueryRecorder\QueryRecorder;
 use Throwable;
 
@@ -37,6 +37,13 @@ class FilamentExceptions
         $reporter->reportException($exception);
     }
 
+    /** @return ExceptionModel */
+    public static function model()
+    {
+        $class = config('filament-exceptions.exception_model');
+        return $class;
+    }
+
     /**
      * @return void
      */
@@ -63,7 +70,8 @@ class FilamentExceptions
 
         try {
             $this->store($data);
-        } catch (Throwable $e) {
+        }
+        catch (Throwable $e) {
             throw $e;
         }
     }
@@ -71,7 +79,7 @@ class FilamentExceptions
     /**
      * Convert all items to string.
      */
-    public function stringify($data): array
+    public function stringify($data) : array
     {
         return array_map(function ($item) {
             return is_array($item) ? json_encode($item, JSON_OBJECT_AS_ARRAY) : (string) $item;
@@ -81,18 +89,19 @@ class FilamentExceptions
     /**
      * Store exception info to db.
      */
-    public function store(array $data): bool
+    public function store(array $data) : bool
     {
         try {
-            Exception::query()->create($data);
+            $this->model()::query()->create($data);
 
             return true;
-        } catch (Throwable $e) {
+        }
+        catch (Throwable $e) {
             return false;
         }
     }
 
-    public static function formatFileName(string $fileName): string
+    public static function formatFileName(string $fileName) : string
     {
         return str($fileName)
             ->after(str(request()->getHost())->beforeLast('.')->toString())

--- a/src/FilamentExceptions.php
+++ b/src/FilamentExceptions.php
@@ -101,12 +101,4 @@ class FilamentExceptions
         }
     }
 
-    public static function formatFileName(string $fileName) : string
-    {
-        return str($fileName)
-            ->after(str(request()->getHost())->beforeLast('.')->toString())
-            ->afterLast('/')
-            ->prepend('.../')
-            ->toString();
-    }
 }

--- a/src/FilamentExceptions.php
+++ b/src/FilamentExceptions.php
@@ -37,11 +37,12 @@ class FilamentExceptions
         $reporter->reportException($exception);
     }
 
-    /** @return ExceptionModel */
-    public static function model()
+    public static function model() : string
     {
-        $class = config('filament-exceptions.exception_model');
-        return $class;
+        if (config('filament-exceptions.exception_model') === null) {
+            return ExceptionModel::class;
+        }
+        return config('filament-exceptions.exception_model');
     }
 
     /**

--- a/src/Resources/ExceptionResource.php
+++ b/src/Resources/ExceptionResource.php
@@ -2,7 +2,7 @@
 
 namespace BezhanSalleh\FilamentExceptions\Resources;
 
-use BezhanSalleh\FilamentExceptions\Models\Exception;
+use BezhanSalleh\FilamentExceptions\Facades\FilamentExceptions;
 use BezhanSalleh\FilamentExceptions\Resources\ExceptionResource\Pages;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -12,99 +12,103 @@ use Filament\Tables\Table;
 
 class ExceptionResource extends Resource
 {
-    protected static ?string $model = Exception::class;
 
-    public static function getModelLabel(): string
+    public static function getModel() : string
+    {
+        return FilamentExceptions::model();
+    }
+
+    public static function getModelLabel() : string
     {
         return __('filament-exceptions::filament-exceptions.labels.model');
     }
 
-    public static function getPluralModelLabel(): string
+    public static function getPluralModelLabel() : string
     {
         return __('filament-exceptions::filament-exceptions.labels.model_plural');
     }
 
-    public static function getNavigationGroup(): ?string
+    public static function getNavigationGroup() : ?string
     {
         return __('filament-exceptions::filament-exceptions.labels.navigation_group');
     }
 
-    public static function getNavigationLabel(): string
+    public static function getNavigationLabel() : string
     {
         return __('filament-exceptions::filament-exceptions.labels.navigation');
     }
 
-    public static function getNavigationIcon(): string
+    public static function getNavigationIcon() : string
     {
         return config('filament-exceptions.icons.navigation');
     }
 
-    public static function getSlug(): string
+    public static function getSlug() : string
     {
         return config('filament-exceptions.slug');
     }
 
-    public static function getNavigationBadge(): ?string
+    public static function getNavigationBadge() : ?string
     {
         if (config('filament-exceptions.navigation_badge')) {
-            return static::$model::count();
+            return static::getModel()::count();
         }
 
         return null;
     }
 
-    public static function shouldRegisterNavigation(): bool
+    public static function shouldRegisterNavigation() : bool
     {
         return (bool) config('filament-exceptions.navigation_enabled');
     }
 
-    public static function getNavigationSort(): ?int
+    public static function getNavigationSort() : ?int
     {
         return config('filament-exceptions.navigation_sort');
     }
 
-    public static function canGloballySearch(): bool
+    public static function canGloballySearch() : bool
     {
         return config('filament-exceptions.is_globally_searchable')
             && count(static::getGloballySearchableAttributes())
             && static::canViewAny();
     }
 
-    public static function form(Form $form): Form
+    public static function form(Form $form) : Form
     {
         return $form
             ->schema([
                 Forms\Components\Tabs::make('Heading')
-                    ->activeTab(static fn (): int => config('filament-exceptions.active_tab'))
+                    ->activeTab(static fn () : int => config('filament-exceptions.active_tab'))
                     ->tabs([
                         Forms\Components\Tabs\Tab::make('Exception')
-                            ->label(static fn (): string => __('filament-exceptions::filament-exceptions.labels.tabs.exception'))
-                            ->icon(static fn (): string => config('filament-exceptions.icons.exception'))
+                            ->label(static fn () : string => __('filament-exceptions::filament-exceptions.labels.tabs.exception'))
+                            ->icon(static fn () : string => config('filament-exceptions.icons.exception'))
                             ->schema([
                                 Forms\Components\View::make('filament-exceptions::exception'),
                             ]),
                         Forms\Components\Tabs\Tab::make('Headers')
-                            ->label(static fn (): string => __('filament-exceptions::filament-exceptions.labels.tabs.headers'))
-                            ->icon(static fn (): string => config('filament-exceptions.icons.headers'))
+                            ->label(static fn () : string => __('filament-exceptions::filament-exceptions.labels.tabs.headers'))
+                            ->icon(static fn () : string => config('filament-exceptions.icons.headers'))
                             ->schema([
                                 Forms\Components\View::make('filament-exceptions::headers'),
                             ])->columns(1),
                         Forms\Components\Tabs\Tab::make('Cookies')
-                            ->label(static fn (): string => __('filament-exceptions::filament-exceptions.labels.tabs.cookies'))
-                            ->icon(static fn (): string => config('filament-exceptions.icons.cookies'))
+                            ->label(static fn () : string => __('filament-exceptions::filament-exceptions.labels.tabs.cookies'))
+                            ->icon(static fn () : string => config('filament-exceptions.icons.cookies'))
                             ->schema([
                                 Forms\Components\View::make('filament-exceptions::cookies'),
                             ]),
                         Forms\Components\Tabs\Tab::make('Body')
-                            ->label(static fn (): string => __('filament-exceptions::filament-exceptions.labels.tabs.body'))
-                            ->icon(static fn (): string => config('filament-exceptions.icons.body'))
+                            ->label(static fn () : string => __('filament-exceptions::filament-exceptions.labels.tabs.body'))
+                            ->icon(static fn () : string => config('filament-exceptions.icons.body'))
                             ->schema([
                                 Forms\Components\View::make('filament-exceptions::body'),
                             ]),
                         Forms\Components\Tabs\Tab::make('Queries')
-                            ->label(static fn (): string => __('filament-exceptions::filament-exceptions.labels.tabs.queries'))
-                            ->icon(static fn (): string => config('filament-exceptions.icons.queries'))
-                            ->badge(static fn ($record): string => collect(json_decode($record->query, true, 512, JSON_THROW_ON_ERROR))->count())
+                            ->label(static fn () : string => __('filament-exceptions::filament-exceptions.labels.tabs.queries'))
+                            ->icon(static fn () : string => config('filament-exceptions.icons.queries'))
+                            ->badge(static fn ($record) : string => collect(json_decode($record->query, true, 512, JSON_THROW_ON_ERROR))->count())
                             ->schema([
                                 Forms\Components\View::make('filament-exceptions::query'),
                             ]),
@@ -113,46 +117,46 @@ class ExceptionResource extends Resource
             ])->columns(1);
     }
 
-    public static function table(Table $table): Table
+    public static function table(Table $table) : Table
     {
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('method')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.method'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.method'))
                     ->badge()
                     ->colors([
                         'gray',
-                        'success' => fn ($state): bool => $state === 'GET',
-                        'primary' => fn ($state): bool => $state === 'POST',
-                        'warning' => fn ($state): bool => $state === 'PUT',
-                        'danger' => fn ($state): bool => $state === 'DELETE',
-                        'warning' => fn ($state): bool => $state === 'PATCH',
-                        'gray' => fn ($state): bool => $state === 'OPTIONS',
+                        'success' => fn ($state) : bool => $state === 'GET',
+                        'primary' => fn ($state) : bool => $state === 'POST',
+                        'warning' => fn ($state) : bool => $state === 'PUT',
+                        'danger' => fn ($state) : bool => $state === 'DELETE',
+                        'warning' => fn ($state) : bool => $state === 'PATCH',
+                        'gray' => fn ($state) : bool => $state === 'OPTIONS',
 
                     ])
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('path')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.path'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.path'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('type')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.type'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.type'))
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('code')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.code'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.code'))
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: false),
                 Tables\Columns\TextColumn::make('ip')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.ip'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.ip'))
                     ->badge()
                     ->extraAttributes(['class' => 'font-mono'])
                     ->sortable()
                     ->searchable()
                     ->toggleable(isToggledHiddenByDefault: false),
                 Tables\Columns\TextColumn::make('created_at')
-                    ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.occurred_at'))
+                    ->label(fn () : string => __('filament-exceptions::filament-exceptions.columns.occurred_at'))
                     ->sortable()
                     ->searchable()
                     ->dateTime()
@@ -173,14 +177,14 @@ class ExceptionResource extends Resource
             ->defaultSort('created_at', 'desc');
     }
 
-    public static function getRelations(): array
+    public static function getRelations() : array
     {
         return [
             //
         ];
     }
 
-    public static function getPages(): array
+    public static function getPages() : array
     {
         return [
             'index' => Pages\ListExceptions::route('/'),

--- a/src/Trace/Parser.php
+++ b/src/Trace/Parser.php
@@ -10,7 +10,7 @@ class Parser implements Iterator
     {
     }
 
-    public function parse(): ?array
+    public function parse() : ?array
     {
         $frames = explode("\n", $this->trace);
 
@@ -22,6 +22,7 @@ class Parser implements Iterator
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         // TODO: Implement current() method.
@@ -30,6 +31,7 @@ class Parser implements Iterator
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         // TODO: Implement next() method.
@@ -38,6 +40,7 @@ class Parser implements Iterator
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         // TODO: Implement key() method.
@@ -46,6 +49,7 @@ class Parser implements Iterator
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         // TODO: Implement valid() method.
@@ -54,6 +58,7 @@ class Parser implements Iterator
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         // TODO: Implement rewind() method.


### PR DESCRIPTION
## Custom Models

Custom models are required in some scenarios such as having a multi tenant database where we want to enforce that the model uses the central database.

Changes made:

- Addded model option to configuration file
- Removed $model property and references in the Filament Resource and replaced with function getModel()
- Added Model method on FilamentExceptions.php that returns model class
- Added backwards compatibility to the model method
- Updated README.md to explain how to use this new feature

Closes #44 

## Fix Iterator Errors
In order to temporarily supress warnings & errors the \ReturnTypeWillChange attribute has been added to functions inside parser.php

Closes #45 