### PR TITLE
Add select columns 

### DIFF
--- a/src/Resources/ExceptionResource.php
+++ b/src/Resources/ExceptionResource.php
@@ -124,6 +124,7 @@ class ExceptionResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->select('id', 'path', 'method', 'type', 'code', 'ip', 'created_at'))
             ->columns([
                 Tables\Columns\TextColumn::make('method')
                     ->label(fn (): string => __('filament-exceptions::filament-exceptions.columns.method'))


### PR DESCRIPTION
The ExceptionModel can be quite big, as it carries with himself information about the headers, queries and trace.
Since those fields aren't shown in the table there is no need to load all those heavy information, I modified the query used to retrieve the models by selecting only the fields we are displaying.


Before:
![image](https://github.com/user-attachments/assets/378bf3ff-8c46-4de8-9b4d-7ed42ec2ab35)

After:
![image](https://github.com/user-attachments/assets/970e8918-d5f6-432b-a8e6-15652d38ee34)
This pull request to `src/Resources/ExceptionResource.php` includes a change to enhance the functionality of the `form` method by modifying the query used in the `table` method. The most important change is: