### PR TITLE
Spanish Lang

### DIFF
--- a/resources/lang/es/filament-exceptions.php
+++ b/resources/lang/es/filament-exceptions.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    'labels' => [
+        'model' => 'Excepción',
+        'model_plural' => 'Excepciones',
+        'navigation' => 'Excepción',
+        'navigation_group' => 'Configuración',
+
+        'tabs' => [
+            'exception' => 'Excepción',
+            'headers' => 'Encabezados',
+            'cookies' => 'Cookies',
+            'body' => 'Cuerpo',
+            'queries' => 'Consultas',
+        ],
+    ],
+
+    'empty_list' => '¡Hurra! Relájate y disfruta 😎',
+
+    'columns' => [
+        'method' => 'Método',
+        'path' => 'Ruta',
+        'type' => 'Tipo',
+        'code' => 'Código',
+        'ip' => 'IP',
+        'occurred_at' => 'Ocurrido en',
+    ],
+
+];


### PR DESCRIPTION
Hello, this pull request introduces a new Spanish language translation file for exception-related labels and messages in the `resources/lang/es/filament-exceptions.php` file. 

Localization:

* Added a new Spanish translation file (`resources/lang/es/filament-exceptions.php`) containing labels, tab names, an empty list message, and column headers for exception-related content.