### PR TITLE
Fix: delegate getNavigationBadgeColor() to plugin

### DIFF
--- a/src/Resources/ExceptionResource.php
+++ b/src/Resources/ExceptionResource.php
@@ -75,6 +75,11 @@ class ExceptionResource extends Resource
             ? (string) static::getEloquentQuery()->count()
             : null;
     }
+    
+    public static function getNavigationBadgeColor(): string | array | null
+    {
+        return static::getPlugin()->getNavigationBadgeColor();
+    }
 
     public static function shouldRegisterNavigation(): bool
     {


### PR DESCRIPTION
All other navigation methods in `ExceptionResource` delegate to the plugin, but `getNavigationBadgeColor()` was missing, causing `->navigationBadgeColor()` to have no effect.