### PR TITLE
Fix broken badge link for the code-style workflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <a href="https://github.com/bezhansalleh/filament-exceptions/actions?query=workflow%3Arun-tests+branch%3Amain" class="filament-hidden">
         <img alt="Tests Passing" src="https://img.shields.io/github/actions/workflow/status/bezhansalleh/filament-exceptions/run-tests.yml?style=for-the-badge&logo=github&label=tests">
     </a>
-    <a href="https://github.com/bezhansalleh/filament-exceptions/actions?query=workflow%3A"Check+%26+fix+styling"+branch%3Amain" class="filament-hidden">
+    <a href="https://github.com/bezhansalleh/filament-exceptions/actions/workflows/fix-php-code-style-issues.yml?query=branch%3Amain" class="filament-hidden">
         <img alt="Code Style Passing" src="https://img.shields.io/github/actions/workflow/status/bezhansalleh/filament-exceptions/fix-php-code-style-issues.yml?style=for-the-badge&logo=github&label=code%20style">
     </a>
 


### PR DESCRIPTION
This fixes a broken link inside the code style badge, which resulted in a broken redirect target and while most parsers are ignoring this, some md parsers like phpStorm just stopped parsing the file after the link 

<img width="3736" height="1936" alt="CleanShot 2026-05-23 at 13 52 51" src="https://github.com/user-attachments/assets/07928784-dff3-411e-8e6e-4ff59d27e597" />

